### PR TITLE
fix(brightness): tuya maximum brightness set to 1000 by api

### DIFF
--- a/src/accessories/characteristics/brightness.ts
+++ b/src/accessories/characteristics/brightness.ts
@@ -38,7 +38,7 @@ export class BrightnessCharacteristic extends TuyaWebCharacteristic {
 
   public get rangeMapper(): MapRange {
     let minTuya = 10;
-    let maxTuya = 100;
+    let maxTuya = 1000;
     if (
       this.accessory.deviceConfig.config?.min_brightness !== undefined &&
       this.accessory.deviceConfig.config?.max_brightness !== undefined


### PR DESCRIPTION
Hello,

I found out an issue with the plugin while using it with a connected light bulb, it seems like console was displaying a warning: 

![Screenshot 2021-12-20 at 13 08 14](https://user-images.githubusercontent.com/15812968/146765076-70435e4e-cf34-43fd-8f76-ee2c6bbcd56c.png)

I believe this is due to Tuya API changes from 100 to 1000 maximum of brightness. I made this little change right into brightness characteristics and tested it locally it seems to work just fine.