### PR TITLE
Handle "auth exceed" error from Tuya API

### DIFF
--- a/src/api/service.ts
+++ b/src/api/service.ts
@@ -29,7 +29,8 @@ export class TuyaWebApi {
     private password: string,
     private countryCode: string,
     private tuyaPlatform: TuyaPlatform = "tuya",
-    private log?: Logger
+    private log?: Logger,
+    private authTokenWaitTime: number = 180
   ) {}
 
   public async getAllDeviceStates(): Promise<TuyaDevice[] | undefined> {
@@ -195,11 +196,11 @@ export class TuyaWebApi {
 
     if (data.responseStatus === "error") {
       if (
-        data.errorMsg === "you cannot auth exceed once in 60 seconds" &&
+        data.errorMsg.includes("Authentication error: you cannot auth exceed once in") &&
         !retryingAfterError
       ) {
-        this.log?.warn("Cannot acquire token, waiting 65 seconds.");
-        await delay(65 * 1000);
+        this.log?.warn("Cannot acquire token, waiting ${this.authTokenWaitTime} seconds.");
+        await delay(this.authTokenWaitTime * 1000);
         this.log?.info("Retrying authentication after previous error.");
         return this.getOrRefreshToken(true);
       }

--- a/src/config.ts
+++ b/src/config.ts
@@ -26,6 +26,7 @@ type Config = {
     countryCode?: string;
     platform?: TuyaPlatform;
     pollingInterval?: number;
+    authTokenWaitTime?: number;
   };
   defaults?: Partial<TuyaDeviceDefaults>[];
   scenes?: boolean | string[];

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -102,7 +102,8 @@ export class TuyaWebPlatform implements DynamicPlatformPlugin {
       options.password,
       options.countryCode,
       options.platform,
-      this.log
+      this.log,
+      options.authTokenWaitTime
     );
 
     // When this event is fired it means Homebridge has restored all cached accessories from disk.


### PR DESCRIPTION
This PR addresses a bug preventing the plugin from working around the authentication error "auth exceeded" returned by the Tuya API when authentication is attempted more frequently than once every 180 seconds.

The code to handle this was already there, but it was checking for an exact string that doesn't match the error message currently returned by the Tuya API (which says "180 seconds" instead of 60):
`data.errorMsg === "you cannot auth exceed once in 60 seconds"`

In order to fix this, I
* Introduced configuration variable to wait a custom amount of time in case of "auth exceeded" error message  defaulting
* check for a partial string matching the current error message, hoping that if the Tuya API's changes again the amount of time needed before 2 consecutive auth calls the plugin will be ready to the change

@milo526 please take a look!

