### PR TITLE
fix: add request timeout to Tuya Web API calls

### DIFF
--- a/src/api/service.ts
+++ b/src/api/service.ts
@@ -21,6 +21,12 @@ import delay from "../helpers/delay";
 import { DeviceOfflineError } from "../errors/DeviceOfflineError";
 import { URLSearchParams } from "url";
 
+// Requests to the Tuya Web API had no timeout, so on hosts where the request
+// stalls at the network layer (e.g. a broken IPv6 route to px1.tuya*.com that
+// never fails over to IPv4) the call hangs indefinitely with no error and no
+// log output, silently freezing token refresh, discovery and device control.
+const REQUEST_TIMEOUT_MS = 15000;
+
 export class TuyaWebApi {
   private session: Session | undefined;
   private authBaseUrl = "https://px1.tuyaeu.com";
@@ -178,6 +184,7 @@ export class TuyaWebApi {
           baseURL: this.authBaseUrl,
           data: formData,
           method: "POST",
+          timeout: REQUEST_TIMEOUT_MS,
         })
       ).data;
     } else {
@@ -266,6 +273,7 @@ export class TuyaWebApi {
       url,
       data,
       method,
+      timeout: REQUEST_TIMEOUT_MS,
     });
 
     return { data: response.data as T & { header: TuyaResponseHeader } };


### PR DESCRIPTION
## Summary
- Requests to `px1.tuya*.com` in `TuyaWebApi` (auth, refresh, discovery, get/set device state) had no `timeout` configured.
- On a host where the connection stalls at the network layer — I hit this with a broken/unreachable IPv6 route to the Tuya host that never fell back to IPv4 — the request hangs indefinitely with no error thrown and nothing logged. This silently freezes token refresh, `discoverDevices()` (so cloud polling never starts / never logs "Enable cloud polling"), and device control, until the whole process is restarted.
- Adds a 15s timeout to both request sites (`getOrRefreshToken`'s initial auth call and the shared `sendRequest`) so a stalled connection fails fast and visibly (existing error handling/logging already covers this) instead of hanging forever.

Confirmed locally: an axios request to `px1.tuyaeu.com` without a timeout hung indefinitely when the connection attempted IPv6, while the same request completed in ~1s once a timeout (or IPv4) was forced.

## Test plan
- [x] `npm run build` — no new TypeScript errors introduced by this change (repo's `main` currently fails to build for an unrelated pre-existing reason in `BaseAccessory.ts`, confirmed present before this change too)
- [ ] Maintainer/community verification against a live account, since I don't have a way to run the project's test suite against Tuya's live API in this environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)